### PR TITLE
Add support for Teensy 4.1 specific pins

### DIFF
--- a/WS2812Serial.cpp
+++ b/WS2812Serial.cpp
@@ -121,6 +121,9 @@ bool WS2812Serial::begin()
 
 #elif defined(__IMXRT1062__)
 	  case 1: // Serial1
+#if defined(ARDUINO_TEENSY41)
+	  case 53:
+#endif
 		uart = &IMXRT_LPUART6; 
 		CCM_CCGR3 |= CCM_CCGR3_LPUART6(CCM_CCGR_ON);
 		hwtrigger = DMAMUX_SOURCE_LPUART6_TX; 
@@ -141,7 +144,11 @@ bool WS2812Serial::begin()
 		hwtrigger = DMAMUX_SOURCE_LPUART3_TX; 
 		break;
 	  case 20: // Serial5
+#if defined(ARDUINO_TEENSY40)
 	  case 39: // Serial5 alt
+#elif defined(ARDUINO_TEENSY41)
+	  case 47:
+#endif
 		uart = &IMXRT_LPUART8; 
 		CCM_CCGR6 |= CCM_CCGR6_LPUART8(CCM_CCGR_ON);
 		hwtrigger = DMAMUX_SOURCE_LPUART8_TX; 
@@ -156,6 +163,13 @@ bool WS2812Serial::begin()
 		CCM_CCGR5 |= CCM_CCGR5_LPUART7(CCM_CCGR_ON);
 		hwtrigger = DMAMUX_SOURCE_LPUART7_TX; 
 		break;
+#if defined(ARDUINO_TEENSY41)
+	  case 35:
+		uart = &IMXRT_LPUART5; 
+		CCM_CCGR3 |= CCM_CCGR3_LPUART5(CCM_CCGR_ON);
+		hwtrigger = DMAMUX_SOURCE_LPUART5_TX; 
+		break;
+#endif		
 #endif
 	  default:
 		return false; // pin not supported

--- a/examples/BasicTest/BasicTest.ino
+++ b/examples/BasicTest/BasicTest.ino
@@ -15,6 +15,7 @@ const int pin = 1;
 //   Teensy 3.5:  1, 5, 8, 10, 26, 32, 33, 48
 //   Teensy 3.6:  1, 5, 8, 10, 26, 32, 33
 //   Teensy 4.0:  1, 8, 14, 17, 20, 24, 29, 39
+//   Teensy 4.1:  1, 8, 14, 17, 20, 24, 29, 35, 47, 53
 
 byte drawingMemory[numled*3];         //  3 bytes per LED
 DMAMEM byte displayMemory[numled*12]; // 12 bytes per LED

--- a/examples/BasicTest_RGBW/BasicTest_RGBW.ino
+++ b/examples/BasicTest_RGBW/BasicTest_RGBW.ino
@@ -15,6 +15,7 @@ const int pin = 1;
 //   Teensy 3.5:  1, 5, 8, 10, 26, 32, 33, 48
 //   Teensy 3.6:  1, 5, 8, 10, 26, 32, 33
 //   Teensy 4.0:  1, 8, 14, 17, 20, 24, 29, 39
+//   Teensy 4.1:  1, 8, 14, 17, 20, 24, 29, 35, 47, 53
 
 byte drawingMemory[numled*4];         //  4 bytes per LED for RGBW
 DMAMEM byte displayMemory[numled*16]; // 16 bytes per LED for RGBW

--- a/examples/FastLED_Cylon/FastLED_Cylon.ino
+++ b/examples/FastLED_Cylon/FastLED_Cylon.ino
@@ -13,6 +13,8 @@
 //   Teensy 3.5:  1, 5, 8, 10, 26, 32, 33, 48
 //   Teensy 3.6:  1, 5, 8, 10, 26, 32, 33
 //   Teensy 4.0:  1, 8, 14, 17, 20, 24, 29, 39
+//   Teensy 4.1:  1, 8, 14, 17, 20, 24, 29, 35, 47, 53
+
 #define DATA_PIN 1
 
 // Define the array of leds


### PR DESCRIPTION
Mostly the same as T4, except
a few different alternate Uart pins, plus Serial8 was added.

@PaulStoffregen  - Warning I have not tried it out, did verify it compiles for T4 and T4.1

This is in regards to the forum thread:
https://forum.pjrc.com/threads/64760-T4-1-WS2812B-Can-I-use-Serial-8?p=261271#post261271

I also updated the examples to mention T4.1...

Quest is should I also go through and add MICROMOD?  Or is that still a ways off? 